### PR TITLE
Add `users.profile.me:read` scope to default scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And register `https://YOURSERVER/auth/chatwork/callback` to *Redirect URI*
 ## Configuring
 * `scope` : `String` or `Array`
   * A list of permissions you want to request from the user
-  * default is `["rooms.all:read_write"]`
+  * default is `["rooms.all:read_write", "users.profile.me:read"]`
   * see Appendix scope list of http://download.chatwork.com/ChatWork_API_Documentation.pdf (en) or http://developer.chatwork.com/ja/oauth.html#secAppendix (ja)
 
 ## Auth Hash

--- a/lib/omniauth/strategies/chatwork.rb
+++ b/lib/omniauth/strategies/chatwork.rb
@@ -4,7 +4,7 @@ require "faraday"
 module OmniAuth
   module Strategies
     class Chatwork < ::OmniAuth::Strategies::OAuth2
-      DEFAULT_SCOPE = "rooms.all:read_write"
+      DEFAULT_SCOPE = "rooms.all:read_write users.profile.me:read"
 
       option :client_options, {
         site:          "https://api.chatwork.com/v2",


### PR DESCRIPTION
https://github.com/sue445/omniauth-chatwork/blob/v0.1.0/lib/omniauth/strategies/chatwork.rb#L38

`GET /me` requires `users.profile.me:read`

```
E, [2018-01-31T08:30:10.699175 #1736] ERROR -- omniauth: (chatwork) Authentication failure! invalid_credentials: OAuth2::Error, :
{"errors":["Access token has insufficient scope"]}
```