### PR TITLE
Don't override RUBY_OPT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - bundle exec rspec
+  - RUBYOPT=$RSPEC_RUBYOPT bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 branches:
@@ -32,9 +32,9 @@ matrix:
     - rvm: ruby-head
   include:
     - rvm: 2.6
-      env: RUBYOPT="--jit"
+      env: RSPEC_RUBYOPT="--jit"
     - rvm: ruby-head
-      env: RUBYOPT="--jit"
+      env: RSPEC_RUBYOPT="--jit"
 env:
   global:
     - CC_TEST_REPORTER_ID=57923c0aa656e8d9cf7af9aa9cfbbae06e909e53c8282d2eb428b7b97157e26d


### PR DESCRIPTION
`ruby: invalid option --jit` error before running rspec.

So I imagine travis internal script is ruby < 2.6 

https://travis-ci.org/sue445/omniauth-chatwork/jobs/547478106